### PR TITLE
rename cache store, make readme more uniform, fix readme errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,26 +6,32 @@ You'll need an account at [Iron.io](http://www.iron.io) first.
 
 Then add this gem to your Gemfile:
 
-    gem 'iron_cache_rails'
+```ruby
+gem 'iron_cache_rails'
+```
 
 ## Using As Rails Store
 
-You can use IronCache as any other rails store. Put iron.json into your project's config dir, add iron_cache to Gemfile and you are ready to go.
+You can use IronCache as any other rails store. Put iron.json into your project's config dir, add iron_cache_rails to Gemfile and you are ready to go.
 
-    config.cache_store = :iron_cache_store
+```ruby
+config.cache_store = :iron_cache
+```
 
 Alternatively, you can supply project_id and token in code.
 
-    config.cache_store = :iron_cache_store, :project_id => 'XXX', :token => 'YYY'
+```ruby
+config.cache_store = :iron_cache, project_id: 'XXX', token: 'YYY'
+```
 
 ## Using As Rails Session Store
 
-You can use IronCache as any other rails session store. Put iron.json into your project's config dir, add iron_cache to Gemfile and you are ready to go.
+You can use IronCache as any other rails session store. Put iron.json into your project's config dir, add iron_cache_rails to Gemfile and you are ready to go.
 
 `config/initializers/session_store.rb` :
 
 ```ruby
-AppName::Application.config.session_store :iron_cache_store
+AppName::Application.config.session_store :iron_cache
 ```
 
 Alternatively, you can supply project_id and token in code.

--- a/lib/active_support/cache/iron_cache.rb
+++ b/lib/active_support/cache/iron_cache.rb
@@ -3,12 +3,12 @@ require 'base64'
 
 module ActiveSupport
   module Cache
-    class IronCacheStore < ActiveSupport::Cache::Store
+    class IronCache < ActiveSupport::Cache::Store
 
       def initialize(options = nil)
         super(options)
 
-        @client = IronCache::Client.new(@options)
+        @client = ::IronCache::Client.new(@options)
 
         extend ActiveSupport::Cache::Strategy::LocalCache
       end


### PR DESCRIPTION
- Rename cache store to be more consistent: `:iron_cache_store` => `:iron_cache`
- Fix readme errors
- Make readme more uniform
